### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/persimmon/view/blocks/smart_bubble.py
+++ b/persimmon/view/blocks/smart_bubble.py
@@ -8,7 +8,7 @@ from kivy.properties import ObjectProperty, StringProperty, ListProperty
 import inspect
 import logging
 from functools import reduce
-from fuzzywuzzy import process
+from rapidfuzz import process
 from typing import List, Optional
 from kivy.input import MotionEvent
 from kivy.uix.recycleview import RecycleView

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ colorama==0.3.9
 crayons==0.1.2
 cycler==0.10.0
 docutils==0.13.1
-fuzzywuzzy==0.15.0
 humanfriendly==3.2
 Jinja2==2.9.6
 Kivy==1.10.0
@@ -23,6 +22,7 @@ pyparsing==2.2.0
 pytest==3.1.2
 python-dateutil==2.6.0
 pytz==2017.2
+rapidfuzz==0.2.1
 requests==2.14.2
 six==1.10.0
 typed-ast==1.0.4

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(name='persimmon',
       include_package_data=True,
       python_requires='>=3.5',
       setup_requires=['Cython'],
-      install_requires=['Cython', 'Kivy', 'scikit-learn', 'pandas', 'fuzzywuzzy', 'pymitter'],
+      install_requires=['Cython', 'Kivy', 'scikit-learn', 'pandas', 'rapidfuzz', 'pymitter'],
       zip_safe=False,
       classifiers=[
           'Development Status :: 3 - Alpha',


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2. I had the same problem on one of my projects and so I wrote [rapidfuzz](https://github.com/rhasspy/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed and is therefor MIT Licensed aswell, so it can be used in here without forcing a License change. As a nice bonus it is fully implemented in C++ and comes with a few Algorithmic improvements making it between 5 and 100 times faster than FuzzyWuzzy.